### PR TITLE
Bug fix logout artistas

### DIFF
--- a/Codigo/ArenaGestor/ArenaGestor.API/Controllers/SecurityController.cs
+++ b/Codigo/ArenaGestor/ArenaGestor.API/Controllers/SecurityController.cs
@@ -32,7 +32,7 @@ namespace ArenaGestor.API.Controllers
         }
 
         [HttpPost("logout")]
-        [AuthorizationFilter(RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador)]
+        [AuthorizationFilter(RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador, RoleCode.Artista)]
         public IActionResult Logout([FromHeader] string token)
         {
             this.securityService.Logout(token);


### PR DESCRIPTION
Se agregó el rol de artista al auth filter en el endpoint de logout del SecurityController.
Al tratarse de un cambio en los filtros de la WebApi, no pudimos aplicar TDD de forma estricta, dado que no es posible hacer pruebas unitarias de los filtros de un endpoint en particular. De todas formas quisimos acercanos lo maximo posible a TDD, por lo que se aplicó esta metodologia utilizando tests de integración en vez de unitarios. Estos tests de integración fueron realizados con swagger UI, y no son visibles en el codigo, por lo que los documentaremos:
Teniendo una sesión iniciada con un usuario de rol artista, antes de reparar el bug comenzamos corriendo un test de integración que falló:
![image](https://user-images.githubusercontent.com/49622428/232936255-8c23a55d-0395-4103-ac98-1af3acd80ebf.png)
Se puede observar que el usuario que intentó terminar la sesión no tiene permisos para hacerlo, pero debería tenerlos.

Luego, reparamos el bug y corrimos el test nuevamente. Esta vez si cuenta con los permisos para hacerlo y el endpoint devuelve true:
![image](https://user-images.githubusercontent.com/49622428/232936839-defb38d7-5613-4a27-99d6-8458d8d0294b.png)
